### PR TITLE
[FIX] Increase PicoFeed MaxBodySize from 2MB to 16MB

### DIFF
--- a/feed/feedupdater.php
+++ b/feed/feedupdater.php
@@ -27,6 +27,7 @@ use OCA\Podcasts\Db\EpisodeMapper;
 use OCA\Podcasts\Db\Feed;
 use OCA\Podcasts\Db\FeedMapper;
 use PicoFeed\Reader\Reader;
+use PicoFeed\Config\Config;
 
 /**
  * Class FeedUpdater
@@ -92,7 +93,9 @@ class FeedUpdater
         $success = false;
 
         try {
-            $reader = new Reader();
+            $config = new Config();
+            $config->setMaxBodySize(1024*1024*16);// 16MB, default is 2097152 (2MB)
+            $reader = new Reader($config);
             $resource = $reader->download($feed->getUrl());
 
             $parser = $reader->getParser(
@@ -121,7 +124,9 @@ class FeedUpdater
      */
     public function processFeed(Feed $feed)
     {
-        $reader = new Reader();
+        $config = new Config();
+        $config->setMaxBodySize(1024*1024*16);// 16MB, default is 2097152 (2MB)
+        $reader = new Reader($config);
         $resource = $reader->download($feed->getUrl());
 
         $parser = $reader->getParser(


### PR DESCRIPTION
Hi,

this PR fixes e.g. http://www.wrint.de/feed/, which has about 4MB.

Best Regards,
Nils